### PR TITLE
Add error output to exec error messages

### DIFF
--- a/flowtype/commands/exec_flow.py
+++ b/flowtype/commands/exec_flow.py
@@ -46,5 +46,9 @@ class ExecFlowCommand(threading.Thread):
 
             os.close(read)
         except subprocess.CalledProcessError as err:
-            self.stderr = str(err)
+            if type(err.output) is bytes:
+                output = err.output.decode('utf-8')
+            else:
+                output = err.output
+            self.stderr = str(err) + ': ' + str(output)
             self.returncode = 1


### PR DESCRIPTION
e.g. for an error like "env: ‘node’: No such file or directory"
the sublime console was only reporting "exited with code 127"
which wasn't very helpful in determining the cause.